### PR TITLE
Fix type declaration for vertices

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ interface Vertex {
 }
 
 declare class Graph {
-	vertices: { [key: string]: Vertex[] };
+	vertices: { [key: string]: Vertex };
 	add(key: string, descendants: string[] | string): Graph;
 	reset(): void;
 	addAndVerify(key: string, descendants: string[] | string): Graph;


### PR DESCRIPTION
Looking at the code, it seems like the `vertices` object maps from key to an individual `Vertex`.